### PR TITLE
Update load_policy

### DIFF
--- a/jni/sepolicy-inject/sepolicy-inject.c
+++ b/jni/sepolicy-inject/sepolicy-inject.c
@@ -111,6 +111,7 @@ int load_policy(char *filename, policydb_t *policydb, struct policy_file *pf) {
 	if (map == MAP_FAILED) {
 		fprintf(stderr, "Can't mmap '%s':  %s\n",
 		        filename, strerror(errno));
+		close(fd);
 		return 1;
 	}
 
@@ -120,14 +121,20 @@ int load_policy(char *filename, policydb_t *policydb, struct policy_file *pf) {
 	pf->len = sb.st_size;
 	if (policydb_init(policydb)) {
 		fprintf(stderr, "policydb_init: Out of memory!\n");
+		munmap(map, sb.st_size);
+		close(fd);
 		return 1;
 	}
 	ret = policydb_read(policydb, pf, 1);
 	if (ret) {
 		fprintf(stderr, "error(s) encountered while parsing configuration\n");
+		munmap(map, sb.st_size);
+		close(fd);
 		return 1;
 	}
 
+	munmap(map, sb.st_size);
+	close(fd);
 	return 0;
 }
 


### PR DESCRIPTION
Clean-up map and fd when return, release /sys/fs/selinux/policy in case multiple load is required during the life-cycle of this program. May be needed for multiple-rule support?